### PR TITLE
Fix background color, resolve Google API JS loading in Gutenberg, resolve issue with Establishment results of non-businesses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
     build:
         uses: impress-org/givewp-github-actions/.github/workflows/wp-org-release.yml@master
         with:
+            install_composer_packages: false
             wp_org_slug: google-places-reviews
             zip_name: google-places-reviews
             text_domain: google-places-reviews

--- a/google-places-reviews.php
+++ b/google-places-reviews.php
@@ -3,7 +3,7 @@
  * Plugin Name: Reviews Block for Google
  * Plugin URI: https://wpbusinessreviews.com/
  * Description: Easily display Google business reviews and ratings with a simple and intuitive WordPress block.
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: WP Business Reviews
  * Author URI: https://wpbusinessreviews.com/
  * Requires PHP: 7.2
@@ -14,7 +14,7 @@
  */
 
 // Define Constants
-define('GPR_VERSION', '2.0.0');
+define('GPR_VERSION', '2.0.1');
 define('GPR_PLUGIN_FILE', __FILE__);
 define('GPR_PLUGIN_NAME', plugin_basename(GPR_PLUGIN_FILE));
 define('GPR_PLUGIN_PATH', plugin_dir_path(GPR_PLUGIN_FILE));

--- a/includes/gpr-class.php
+++ b/includes/gpr-class.php
@@ -237,11 +237,8 @@ class WP_Google_Places_Reviews_Free {
      */
     function render_block( $attributes, $content ) {
 
-        if ( is_admin() ) {
-            // Need API key localized for admin only so that autocomplete works.
-
-        } else {
-            // Only frontend scripts.
+        // Only frontend scripts.
+        if ( ! is_admin() ) {
             wp_enqueue_script( 'reviews-block-google-script' );
             wp_set_script_translations( 'reviews-block-google-script', 'google-places-reviews' );
         }

--- a/includes/gpr-class.php
+++ b/includes/gpr-class.php
@@ -41,7 +41,6 @@ class WP_Google_Places_Reviews_Free {
 
         add_action( 'init', [ $this, 'load_plugin_textdomain' ] );
         add_action( 'init', [ $this, 'register_settings' ] );
-
         add_action( 'rest_api_init', [ $this, 'google_api_rest_endpoint' ] );
 
         // Register the widget if using older version of WP or Classic Widgets plugin is installed.
@@ -213,10 +212,6 @@ class WP_Google_Places_Reviews_Free {
             $assets['version']
         );
 
-        if ( ! empty( $this->api_key ) ) {
-            wp_register_script( 'reviews-block-google-autocomplete', 'https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&key=' . $this->api_key, [] );
-        }
-
         register_block_type(
             GPR_PLUGIN_PATH,
             [ 'render_callback' => [ $this, 'render_block' ], ]
@@ -226,10 +221,12 @@ class WP_Google_Places_Reviews_Free {
     /**
      * Enqueue the block's admin assets.
      * @return void
-     * @since 3.0.0
+     * @since 2.0.0
      */
     public function enqueue_block_admin_assets() {
-        wp_enqueue_script( 'reviews-block-google-autocomplete' );
+        wp_localize_script( 'google-places-reviews-reviews-editor-script', 'googleBlockSettings', [
+            'apiKey' => $this->api_key,
+        ] );
     }
 
     /**
@@ -240,7 +237,11 @@ class WP_Google_Places_Reviews_Free {
      */
     function render_block( $attributes, $content ) {
 
-        if ( ! is_admin() ) {
+        if ( is_admin() ) {
+            // Need API key localized for admin only so that autocomplete works.
+
+        } else {
+            // Only frontend scripts.
             wp_enqueue_script( 'reviews-block-google-script' );
             wp_set_script_translations( 'reviews-block-google-script', 'google-places-reviews' );
         }
@@ -265,7 +266,6 @@ class WP_Google_Places_Reviews_Free {
         // Return clean buffer
         return ob_get_clean();
     }
-
 
     /**
      * Register GPR category

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reviews-block-for-google",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Easily display Google business reviews and ratings with a simple and intuitive WordPress block.",
     "main": "index.js",
     "author": "WP Business Reviews",

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: impressorg, dlocc, webdevmattcrom, shawnhooper, jason_the_adams, a
 Donate link: https://wpbusinessreviews.com/
 Tags: google, reviews, google reviews, google places
 Requires at least: 5.0
-Tested up to: 6.0
-Stable tag: 2.0.0
+Tested up to: 6.1
+Stable tag: 2.0.1
 License: GPL2
 
 Easily display Google business reviews and ratings with a simple and intuitive WordPress block.

--- a/readme.txt
+++ b/readme.txt
@@ -13,13 +13,13 @@ Easily display Google business reviews on your WordPress website with a simple a
 
 This free Google Reviews block includes a variety of options to customize how you display your Google Business information. 
 
-Great for restaurants, retail stores, franchisees, real estate firms, hotels and hospitality, and nearly any business with Google Revies.
+Great for restaurants, retail stores, franchisees, real estate firms, hotels and hospitality, and nearly any business with Google Reviews.
 
 === ✨ Reviews Block for Google Features ===
 
 The Reviews Block for Google allows you to display up to 5 business reviews. Setup is quick and easy. Simply install the plugin, insert your Google API key (instructions provided), and drag the block into the block editor to configure the options.
 
-Then, choose from block options to dislay or hide your: 
+Then, choose from block options to display or hide your: 
 
 * Businesses' hours
 * Location
@@ -92,9 +92,9 @@ We do our best to support users of the free version of the plugin. [WP Business 
 == Changelog ==
 
 = 2.0.1: May 26th, 2022 =
-* 🎨 Added a CSS tweak so the business review card has a white background. 
+* 🎨 Added CSS so the business review card has a white background and not transparent. This improves the look on non-white background websites. 
 * 🛠 Optimized loading Google's autocomplete script so it doesn't load unnecessarily when not needed.
-* 🛠 Fix "Google" logo image being overlapped on the API key screen.
+* 🛠 Fix "Google" logo image being overlapped on the API key insertion screen.
 
 = 2.0.0: May 26th, 2022 =
 * 🎉 Introducing the Reviews Block for Google WordPress plugin. This is a huge plugin revamp! In this new version we've added a new reviews block for the WordPress block editor. Don't worry, if you're still using the widget it will still work just fine.

--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ We do our best to support users of the free version of the plugin. [WP Business 
 
 == Changelog ==
 
-= 2.0.1: May 26th, 2022 =
+= 2.0.1: July 1st, 2022 =
 * 🎨 Added CSS so the business review card has a white background and not transparent. This improves the look on non-white background websites. 
 * 🛠 Optimized loading Google's autocomplete script so it doesn't load unnecessarily when not needed.
 * 🛠 Fix "Google" logo image being overlapped on the API key insertion screen.

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,11 @@ We do our best to support users of the free version of the plugin. [WP Business 
 
 == Changelog ==
 
+= 2.0.1: May 26th, 2022 =
+* 🎨 Added a CSS tweak so the business review card has a white background. 
+* 🛠 Optimized loading Google's autocomplete script so it doesn't load unnecessarily when not needed.
+* 🛠 Fix "Google" logo image being overlapped on the API key screen.
+
 = 2.0.0: May 26th, 2022 =
 * 🎉 Introducing the Reviews Block for Google WordPress plugin. This is a huge plugin revamp! In this new version we've added a new reviews block for the WordPress block editor. Don't worry, if you're still using the widget it will still work just fine.
 * What else? The plugin settings have been cleaned up, further secured, and improved.

--- a/src/components/BusinessLookup/index.js
+++ b/src/components/BusinessLookup/index.js
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { TextControl, SelectControl } from '@wordpress/components';
+import { TextControl } from '@wordpress/components';
 import GoogleLogo from '../../images/google-logo.svg';
 
 let autoComplete;
@@ -9,7 +9,6 @@ const loadScript = ( url, callback ) => {
     let script = document.createElement( 'script' );
     script.type = 'text/javascript';
 
-    // Callback fanciness.
     if ( script.readyState ) {
         script.onreadystatechange = function() {
             if ( script.readyState === 'loaded' || script.readyState === 'complete' ) {
@@ -21,7 +20,6 @@ const loadScript = ( url, callback ) => {
         script.onload = () => callback();
     }
 
-    // Only load the script once.
     script.src = url;
     document.getElementsByTagName( 'head' )[0].appendChild( script );
 };
@@ -86,38 +84,11 @@ const BusinessLookup = ( { setAttributes } ) => {
                         label={__( 'Place Name', 'google-places-reviews' )}
                         ref={autoCompleteRef}
                         onChange={event => setLocation( event )}
-                        // onChange={( location ) => {
-                        //     console.log( location );
-                        //     setLocation( location );
-                        //     // handleSearch( location );
-                        // }}
                         help={__(
                             'Enter the name of your place (business name, address, location).',
                             'google-places-reviews',
                         )}
                     />
-
-                    {/* <SelectControl
-                        label={__( 'Place Type', 'google-places-reviews' )}
-                        value={placeType}
-                        options={[
-                            { label: __( 'All', 'google-places-reviews' ), value: 'all' },
-                            { label: __( 'Addresses', 'google-places-reviews' ), value: 'address' },
-                            {
-                                label: __( 'Establishments', 'google-places-reviews' ),
-                                value: 'establishment',
-                            },
-                            { label: __( 'Regions', 'google-places-reviews' ), value: '(regions)' },
-                        ]}
-                        onChange={( placeType ) => {
-                            setPlaceType( placeType );
-                            setAttributes( { placeType } );
-                        }}
-                        help={__(
-                            'Specify how you would like to lookup your Google Place.',
-                            'google-places-reviews',
-                        )}
-                    />*/}
                 </div>
 
             </div>

--- a/src/components/BusinessLookup/index.js
+++ b/src/components/BusinessLookup/index.js
@@ -20,7 +20,6 @@ const BusinessLookup = ( { setAttributes } ) => {
         }
         const autocomplete = new google.maps.places.Autocomplete( locationRef.current, [placeType] );
 
-
         autocomplete.addListener( 'place_changed', () => {
             const { place_id, name } = autocomplete.getPlace();
 

--- a/src/components/BusinessLookup/index.js
+++ b/src/components/BusinessLookup/index.js
@@ -1,40 +1,66 @@
 import { __ } from '@wordpress/i18n';
-import { useState, createRef } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { TextControl, SelectControl } from '@wordpress/components';
 import GoogleLogo from '../../images/google-logo.svg';
 
+let autoComplete;
+
+const loadScript = ( url, callback ) => {
+    let script = document.createElement( 'script' );
+    script.type = 'text/javascript';
+
+    // Callback fanciness.
+    if ( script.readyState ) {
+        script.onreadystatechange = function() {
+            if ( script.readyState === 'loaded' || script.readyState === 'complete' ) {
+                script.onreadystatechange = null;
+                callback();
+            }
+        };
+    } else {
+        script.onload = () => callback();
+    }
+
+    // Only load the script once.
+    script.src = url;
+    document.getElementsByTagName( 'head' )[0].appendChild( script );
+};
 
 const BusinessLookup = ( { setAttributes } ) => {
 
-    const locationRef = createRef();
-
+    const autoCompleteRef = useRef( null );
     const [location, setLocation] = useState( '' );
-    const [placeType, setPlaceType] = useState( 'all' );
+    const urlGoogleMaps = `https://maps.googleapis.com/maps/api/js?key=${window.googleBlockSettings.apiKey}&libraries=places`;
 
-    const handleSearch = ( location ) => {
-
-        setAttributes( { location } );
-
-        if ( location.trim().length < 3 ) {
+    useEffect( () => {
+        let loadedScripts = Array.from( document.querySelectorAll( 'script' ) ).map( scr => scr.src );
+        if ( loadedScripts.includes( urlGoogleMaps ) ) {
+            handleScriptLoad( setLocation, autoCompleteRef );
             return;
         }
-        const autocomplete = new google.maps.places.Autocomplete( locationRef.current, [placeType] );
 
-        autocomplete.addListener( 'place_changed', () => {
-            const { place_id, name } = autocomplete.getPlace();
+        loadScript(
+            urlGoogleMaps,
+            () => handleScriptLoad( setLocation, autoCompleteRef ),
+        );
+    }, [] );
 
-            if ( !place_id ) {
-                // return setState( {
-                //     error: __( 'No place reference found for this location.', 'google-places-reviews' ),
-                // } );
-            }
+    const handleScriptLoad = ( setLocation, autoCompleteRef ) => {
+        autoComplete = new window.google.maps.places.Autocomplete(
+            autoCompleteRef.current,
+            { types: ['establishment'] },
+        );
+        setAttributes( { location } );
 
-            setAttributes( {
-                placeId: place_id,
-                reference: place_id,
-                location: name,
-            } );
-        } );
+        autoComplete.addListener( 'place_changed', () => {
+                const { place_id, name } = autoComplete.getPlace();
+                setAttributes( {
+                    placeId: place_id,
+                    reference: place_id,
+                    location: name,
+                } );
+            },
+        );
     };
 
     return (
@@ -58,19 +84,20 @@ const BusinessLookup = ( { setAttributes } ) => {
                         className={'rbg-admin-field'}
                         name='place_id'
                         label={__( 'Place Name', 'google-places-reviews' )}
-                        value={location}
-                        onChange={( location ) => {
-                            setLocation( location );
-                            handleSearch( location );
-                        }}
-                        ref={locationRef}
+                        ref={autoCompleteRef}
+                        onChange={event => setLocation( event )}
+                        // onChange={( location ) => {
+                        //     console.log( location );
+                        //     setLocation( location );
+                        //     // handleSearch( location );
+                        // }}
                         help={__(
                             'Enter the name of your place (business name, address, location).',
                             'google-places-reviews',
                         )}
                     />
 
-                    <SelectControl
+                    {/* <SelectControl
                         label={__( 'Place Type', 'google-places-reviews' )}
                         value={placeType}
                         options={[
@@ -90,7 +117,7 @@ const BusinessLookup = ( { setAttributes } ) => {
                             'Specify how you would like to lookup your Google Place.',
                             'google-places-reviews',
                         )}
-                    />
+                    />*/}
                 </div>
 
             </div>

--- a/src/components/BusinessLookup/index.js
+++ b/src/components/BusinessLookup/index.js
@@ -52,6 +52,7 @@ const BusinessLookup = ( { setAttributes } ) => {
 
         autoComplete.addListener( 'place_changed', () => {
                 const { place_id, name } = autoComplete.getPlace();
+
                 setAttributes( {
                     placeId: place_id,
                     reference: place_id,

--- a/src/components/GoogleBlock/index.js
+++ b/src/components/GoogleBlock/index.js
@@ -73,7 +73,7 @@ const GoogleBlock = ( props ) => {
                                 </div>
 
                                 <div className={'rbg-business-meta-wrap'}>
-                                    {props.attributes.showBusinessRating && (
+                                    {props.attributes.showBusinessRating && businessData.rating && (
                                         <StarRating
                                             overallRating={businessData.rating}
                                             totalRatings={businessData.user_ratings_total}
@@ -92,13 +92,13 @@ const GoogleBlock = ( props ) => {
                                                         priceLevel={businessData.price_level}
                                                     />
                                                 )}
-                                                {businessData.opening_hours.open_now && (
+                                                {businessData.opening_hours?.open_now && (
                                                     <span
                                                         className={'rbg-business-open-status rbg-business-open-status__open'}>
                                                         {__( 'Open', 'google-places-reviews' )}
                                                     </span>
                                                 )}
-                                                {!businessData.opening_hours.open_now && (
+                                                {!businessData.opening_hours?.open_now && (
                                                     <span
                                                         className={
                                                             'rbg-business-open-status rbg-business-open-status__closed'
@@ -157,10 +157,10 @@ const GoogleBlock = ( props ) => {
                                     </div>
                                 </div>
                             )}
-                            {props.attributes.showHours && (
+                            {props.attributes.showHours && businessData.opening_hours?.weekday_text && (
                                 <div className={'rbg-additional-info-wrap__inner'}>
                                     <h4 className={'rbg-heading'}>{__( 'Hours', 'google-places-reviews' )}</h4>
-                                    <OpenHours days={businessData.opening_hours.weekday_text} />
+                                    <OpenHours days={businessData.opening_hours?.weekday_text} />
                                 </div>
                             )}
                             {props.attributes.showLocation && (
@@ -187,7 +187,7 @@ const GoogleBlock = ( props ) => {
                     {props.attributes.showReviews && (
                         <div className={'rbg-business-reviews-wrap'}>
                             <h3 className={'rbg-heading'}>{__( 'Highlighted Reviews', 'google-places-reviews' )}</h3>
-                            {businessData.reviews.map( ( review, index ) => {
+                            {businessData.reviews?.map( ( review, index ) => {
                                 return <Review key={index} review={review} reviewLines={props.attributes.reviewLines} />;
                             } )}
                         </div>

--- a/src/components/GoogleBlock/index.js
+++ b/src/components/GoogleBlock/index.js
@@ -15,7 +15,6 @@ import Address from '../Address';
 import Review from '../Review';
 import Priciness from '../Priciness';
 
-
 const GoogleBlock = ( props ) => {
 
     const [isLoading, setIsLoading] = useState( true );

--- a/src/components/WelcomeScreen/index.js
+++ b/src/components/WelcomeScreen/index.js
@@ -60,7 +60,6 @@ const WelcomeScreen = ( props ) => {
                     src={GoogleLogo}
                     alt={__( 'Google Logo', 'google-places-reviews' )}
                 />
-                <div id={'google-block-admin-lottie-api'}></div>
                 <h2 className={'rbg-admin-google-welcome-heading'}>
                     {__(
                         'Welcome to the Reviews Block for Google! Let’s get started.',

--- a/src/components/WelcomeScreen/index.js
+++ b/src/components/WelcomeScreen/index.js
@@ -7,7 +7,6 @@ import {
     TextControl,
     Button,
     Icon,
-    Spinner,
 } from '@wordpress/components';
 
 const WelcomeScreen = ( props ) => {

--- a/src/editor.scss
+++ b/src/editor.scss
@@ -15,10 +15,6 @@
         width: 300px;
     }
 
-    #google-block-admin-lottie-api {
-        margin: -70px 0 10px;
-    }
-
     .rbg-admin-welcome-content-wrap {
         max-width: 380px;
         margin: 0 auto 30px;

--- a/src/style.scss
+++ b/src/style.scss
@@ -16,6 +16,7 @@
     border-radius: $border-radius;
     box-shadow: rgba(50, 50, 93, 0.25) 0 6px 12px -2px, rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
     line-height: 1.6;
+    background: #FFF;
 
     a {
         text-decoration: none;

--- a/src/style.scss
+++ b/src/style.scss
@@ -339,6 +339,10 @@
             height: 20px;
         }
 
+        .rbg-business-review-user {
+            max-width: 80px;
+            text-align: center;
+        }
         .rbg-business-review-user-image {
             width: 80px;
             overflow: hidden;


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

There are a variety of issues resolved in this PR. This includes:


1. CSS tweaks for better theme compatibility with non-white backgrounds
2. Optimized Google Maps API loading so that it only loads when the autocomplete search field is present - this field is only used when searching for businesses and once a business has been set it is no longer needed. Prior to this PR we were loading it all the time regardless of whether it was needed or not. See https://github.com/impress-org/reviews-block-for-google/pull/25/files#diff-1b0e61b73fc363fdc1922778a1fc9e2509d25279b102ddf18486d6bc2877d892L217.  Now we're only loading it when needed in the component: https://github.com/impress-org/reviews-block-for-google/pull/25/files#diff-149ec0d9146d30aa47878fb02a19425dd818e1a0cdff4a34aed353983dd0f45bR8
3. Removed the `SelectControl` for "Place Type" because the plugin only displays properly for business establishments or locations with reviews like "Yosemite". It doesn't make sense to allow addresses or Regions to be pulled.
4. Added object chaining to prevent crash and burn when a result like "Mexican Food" is chosen that doesn't have open hours or reviews https://github.com/impress-org/reviews-block-for-google/pull/25/files#diff-bf1167cae67f26d29be34c7d366fc7af45d31a3b970267e4f6c00fc7104a6f04R101
5. Fixed CSS issue with show/hide functionality and avatars with really long names. https://github.com/impress-org/reviews-block-for-google/pull/25/files#diff-c0a5ddd5b365322730802e8cb15c95c3b6e965cbd3e569c69a2f089753844cdbR342
6. Bumped version to `2.0.1` and added change log.
